### PR TITLE
refactor: 스크롤 애니메이션 퍼포먼스 개선

### DIFF
--- a/src/lib/useScrollY.ts
+++ b/src/lib/useScrollY.ts
@@ -25,7 +25,7 @@ const useScrollY = (wait = 50): { scrollY: Ref<number>; centerScrollY: Ref<numbe
 
   const handleDebouceScroll = throttle(onScroll, wait)
 
-  onBeforeMount(() => window.addEventListener("scroll", handleDebouceScroll))
+  onBeforeMount(() => window.addEventListener("scroll", handleDebouceScroll, { passive: true, capture: false }))
   onBeforeUnmount(() => window.removeEventListener("scroll", handleDebouceScroll))
 
   return { scrollY, centerScrollY }

--- a/src/lib/useScrollY.ts
+++ b/src/lib/useScrollY.ts
@@ -1,9 +1,5 @@
-import { ref, onBeforeMount, onBeforeUnmount } from "vue"
+import { ref, onBeforeMount, onBeforeUnmount, Ref } from "vue"
 import throttle from "lodash/throttle"
-
-interface Ref<T> {
-  value: T
-}
 
 /**
  * 문서의 수직 방향으로 얼만큼 스크롤 되었는지 px 단위로 반환
@@ -12,7 +8,12 @@ interface Ref<T> {
  * @param wait Default 50
  * @returns window.pageYOffset || window.scrollY
  */
-const useScrollY = (wait = 50): { scrollY: Ref<number>; centerScrollY: Ref<number> } => {
+const useScrollY = (
+  wait = 50,
+  options = { center_scroll_y: false }
+): { scrollY: Ref<number>; centerScrollY: Ref<number> } => {
+  const { center_scroll_y: center_scroll_y_requested = false } = options
+
   const scrollPosition = window.pageYOffset || window.scrollY
   const scrollY = ref(0)
   const centerScrollY = ref(scrollPosition + window.innerHeight / 2)
@@ -20,7 +21,9 @@ const useScrollY = (wait = 50): { scrollY: Ref<number>; centerScrollY: Ref<numbe
   const onScroll = () => {
     const scrollPosition = window.pageYOffset || window.scrollY
     scrollY.value = scrollPosition // top
-    centerScrollY.value = scrollPosition + window.innerHeight / 2 // center of viewport
+    if (center_scroll_y_requested) {
+      centerScrollY.value = scrollPosition + window.innerHeight / 2 // center of viewport
+    }
   }
 
   const handleDebouceScroll = throttle(onScroll, wait)

--- a/src/lib/useScrollY.ts
+++ b/src/lib/useScrollY.ts
@@ -28,7 +28,7 @@ const useScrollY = (
 
   const handleDebouceScroll = throttle(onScroll, wait)
 
-  onBeforeMount(() => window.addEventListener("scroll", handleDebouceScroll, { passive: true, capture: false }))
+  onBeforeMount(() => window.addEventListener("scroll", handleDebouceScroll, { capture: false }))
   onBeforeUnmount(() => window.removeEventListener("scroll", handleDebouceScroll))
 
   return { scrollY, centerScrollY }

--- a/src/utils/animation_utils.ts
+++ b/src/utils/animation_utils.ts
@@ -82,18 +82,30 @@ const generateScrollAnimationFunctionsByScrollTimeline = (
   })
 }
 
+const getAnimationKeys = (animation: AnimationType[]) => {
+  const animation_keys = new Set<CSSProperties>()
+  animation.map((v) => {
+    const keys = Object.keys(v) as unknown as CSSProperties[]
+    keys.forEach((item) => animation_keys.add(item))
+  })
+  return Array.from(animation_keys)
+}
+
 type AnimationFunctionType = (scroll_percentage: number, element: HTMLElement) => void
 type getAnimationTimelineDataReturnType = {
   start_style: AnimationType
   end_style: AnimationType
   animation_functions: AnimationFunctionType[]
+  animation_keys: CSSProperties[]
 }
 export const getAnimationTimelineData = (animation: AnimationType[]): getAnimationTimelineDataReturnType => {
   const scroll_timeline_data = generateScrollTimeline(animation)
+  const animation_keys = getAnimationKeys(animation)
   const animation_functions = generateScrollAnimationFunctionsByScrollTimeline(scroll_timeline_data)
   return {
     start_style: scroll_timeline_data[0].animation.from,
     end_style: scroll_timeline_data[scroll_timeline_data.length - 1].animation.to,
     animation_functions,
+    animation_keys,
   }
 }

--- a/src/views/components/ScrollAnimation/AnimationSection.vue
+++ b/src/views/components/ScrollAnimation/AnimationSection.vue
@@ -4,7 +4,7 @@
     class="animation-section"
     :style="{ marginBottom: disable_multiple_animation ? '100vh' : '0' }"
   >
-    <Animator :sectionRef="sectionRef" :active="true" :animation="animation">
+    <Animator :sectionRef="() => sectionRef" :active="true" :animation="animation">
       <slot></slot>
     </Animator>
   </section>
@@ -31,7 +31,7 @@ export default defineComponent({
       /**
        * @note
        * Intersection Observer로 isIntersecting 상태에 따라 active 상태를 조절해서 useScrollY(scroll listner)를 disable 하려고 하였으나,
-       * 모바일 디바이스에서 Intersection Observer 동작이 느린 이슈로 사용 불가
+       * IOS 사파리에서 주소창이 가려질 때, Intersection Observer가 동작하지 않는 이슈로 사용 불가
        */
       // active: false,
     }

--- a/src/views/components/ScrollAnimation/Animator.vue
+++ b/src/views/components/ScrollAnimation/Animator.vue
@@ -128,12 +128,19 @@ export default defineComponent({
         const is_out_of_scroll_range = 0 >= scroll_percentage || scroll_percentage >= 100
         if (is_out_of_scroll_range) {
           this.in_range = false
+          if (this.animatorRef?.style) Object.assign(this.animatorRef?.style, { willChange: "unset" })
           if (scroll_percentage <= 0) {
             return this.initializeStartAnimation()
           } else if (scroll_percentage >= 100) {
             return this.initializeEndAnimation()
           }
         }
+
+        if (this.animatorRef?.style)
+          Object.assign(this.animatorRef?.style, {
+            willChange: this.animation_timeline_data.animation_keys.join(","),
+          })
+
         this.in_range = true
         this.animation_timeline_data.animation_functions.forEach((v) => {
           v(scroll_percentage, animatorRef)

--- a/src/views/components/ScrollAnimation/Animator.vue
+++ b/src/views/components/ScrollAnimation/Animator.vue
@@ -105,7 +105,7 @@ export default defineComponent({
 
       const section_top_position = current_scroll - section_offset_top ?? 0
       const scroll_percentage_with_negative = (section_top_position / section_offset_height) * 100
-      const scroll_percentage = Math.round((100 + scroll_percentage_with_negative) / 2)
+      const scroll_percentage = (100 + scroll_percentage_with_negative) / 2
       return scroll_percentage
     },
     initializeStartAnimation: function () {

--- a/src/views/components/ScrollAnimation/Animator.vue
+++ b/src/views/components/ScrollAnimation/Animator.vue
@@ -117,10 +117,13 @@ export default defineComponent({
   watch: {
     scrollY(nv) {
       if (!this.animatorRef || !this.active) return
-      if (this.RAF_timeout) {
-        cancelAnimationFrame(this.RAF_timeout)
-        this.RAF_timeout = undefined
-      }
+      /**
+       * 아래 로직 없을때 퍼포먼스 테스트중
+       */
+      // if (this.RAF_timeout) {
+      //   cancelAnimationFrame(this.RAF_timeout)
+      //   this.RAF_timeout = undefined
+      // }
       const animatorRef = this.animatorRef
       if (!this.section_ref || !animatorRef) return
       this.RAF_timeout = requestAnimationFrame(() => {


### PR DESCRIPTION
현재 onScroll 이벤트를 Listen 하여 계산하는 부분에서 프레임이 떨어짐.
Intersection Observer의 intersectingRatio로 퍼포먼스가 개선되어 프레임이 잘 나오는 것을 확인하였는데, 아래와 같은 문제로 적용 불가.

> IOS Safari에서 스크롤 시 주소창 크기가 변경되는 애니메이션이 있는데, 이 애니메이션이 실행되는 동안 Intersection Observer의 Callback 함수가 동작하지 않는다.

- ~~Intersection Observer로 성능 최적화~~
- will change를 애니메이션 옵션별 가변적으로 추가
- 애니메이션 실행 함수 리팩토링
- 불필요한 로직 제거
